### PR TITLE
add UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "jsnext:main": "dist/index.es.js",
+  "unpkg": "dist/index.umd.js",
   "keywords": [
     "react component",
     "react-loading",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,16 @@ export default {
       file: pkg.module,
       format: 'es',
       sourcemap: true
+    },
+    {
+      file: pkg.unpkg,
+      format: 'umd',
+      sourcemap: true,
+      name: 'ReactTopLoadingBar',
+      globals: {
+        react: 'React',
+        'prop-types': 'PropTypes'
+      }
     }
   ],
   plugins: [


### PR DESCRIPTION
Hi 😄 ,

Great library! I wanted to add a UMD build so I can include this library through a CDN link like from unpkg for small projects that I work on.

The library is then available in the browser as the global: `window.ReactTopLoadingBar`

Right now unpkg will resolve `react-top-loading-bar` to `https://unpkg.com/react-top-loading-bar@1.0.7/dist/index.js` which doesn't work standalone and requires a bundler to actually package up. 

However, with this change unpkg will resolve it to `https://unpkg.com/react-top-loading-bar@1.0.7/dist/index.umd.js` so that the library can be included just as a CDN link and assumes the parent page has React and PropTypes defined 😄 