### PR TITLE
FIX bug with async complete() with continuousStart()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-top-loading-bar",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A very simple, highly customisable react top loader component.",
   "author": {
     "name": "Klendi Gocci",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,6 +82,7 @@ class LoadingBar extends Component<IProps, IState> {
     }
 
     const random = startingValue || this.randomInt(20, 30);
+    this.setState({ progress: random });
 
     const interval = setInterval(() => {
       if (this.state.progress < 90) {
@@ -95,7 +96,7 @@ class LoadingBar extends Component<IProps, IState> {
       }
     }, 1000);
 
-    this.setState({ progress: random, interval });
+    this.setState({ interval });
   };
 
   public continuousStart = (startingValue: number) => {
@@ -103,6 +104,7 @@ class LoadingBar extends Component<IProps, IState> {
       clearInterval(this.state.interval);
     }
     const random = startingValue || this.randomInt(20, 30);
+    this.setState({ progress: random });
 
     const interval = setInterval(() => {
       if (this.state.progress < 90) {
@@ -115,7 +117,7 @@ class LoadingBar extends Component<IProps, IState> {
         clearInterval(interval);
       }
     }, 1000);
-    this.setState({ progress: random, interval });
+    this.setState({ interval });
   };
 
   public staticStart = (startingValue: number) => {
@@ -141,11 +143,7 @@ class LoadingBar extends Component<IProps, IState> {
   private onLoaderFinished = () => {
     if (this.props.onLoaderFinished) this.props.onLoaderFinished();
 
-    if (this.state.interval) {
-      clearInterval(this.state.interval);
-    }
-
-    this.setState({ progress: 0, interval: null }, () => {
+    this.setState({ progress: 0 }, () => {
       this.onProgressChange();
     });
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ type IState = {
   full: boolean;
   progress: number;
   wait: boolean;
+  interval: number;
 };
 
 type IProps = {
@@ -27,7 +28,8 @@ class LoadingBar extends Component<IProps, IState> {
     show: true,
     full: false,
     progress: 0,
-    wait: false
+    wait: false,
+    interval: null
   };
   static propTypes = {
     progress: PropTypes.number,
@@ -75,8 +77,11 @@ class LoadingBar extends Component<IProps, IState> {
 
   /** @deprecated this method contains a typo, use continuousStart */
   public continousStart = (startingValue: number) => {
+    if (this.state.interval) {
+      clearInterval(this.state.interval);
+    }
+
     const random = startingValue || this.randomInt(20, 30);
-    this.setState({ progress: random });
 
     const interval = setInterval(() => {
       if (this.state.progress < 90) {
@@ -89,11 +94,15 @@ class LoadingBar extends Component<IProps, IState> {
         clearInterval(interval);
       }
     }, 1000);
+
+    this.setState({ progress: random, interval });
   };
 
   public continuousStart = (startingValue: number) => {
+    if (this.state.interval) {
+      clearInterval(this.state.interval);
+    }
     const random = startingValue || this.randomInt(20, 30);
-    this.setState({ progress: random });
 
     const interval = setInterval(() => {
       if (this.state.progress < 90) {
@@ -106,18 +115,25 @@ class LoadingBar extends Component<IProps, IState> {
         clearInterval(interval);
       }
     }, 1000);
+    this.setState({ progress: random, interval });
   };
 
   public staticStart = (startingValue: number) => {
+    if (this.state.interval) {
+      clearInterval(this.state.interval);
+    }
     const random = startingValue || this.randomInt(30, 50);
 
-    this.setState({ progress: random }, () => {
+    this.setState({ progress: random, interval: null }, () => {
       this.onProgressChange();
     });
   };
 
   public complete = () => {
-    this.setState({ progress: 100 }, () => {
+    if (this.state.interval) {
+      clearInterval(this.state.interval);
+    }
+    this.setState({ progress: 100, interval: null }, () => {
       this.onProgressChange();
     });
   };
@@ -125,7 +141,11 @@ class LoadingBar extends Component<IProps, IState> {
   private onLoaderFinished = () => {
     if (this.props.onLoaderFinished) this.props.onLoaderFinished();
 
-    this.setState({ progress: 0 }, () => {
+    if (this.state.interval) {
+      clearInterval(this.state.interval);
+    }
+
+    this.setState({ progress: 0, interval: null }, () => {
       this.onProgressChange();
     });
   };


### PR DESCRIPTION
See Issue #15 

Here is an example of the problem:
[https://codesandbox.io/s/long-wind-ud61h](https://codesandbox.io/s/long-wind-ud61h)

If you click the `Fake fetch` button, you will see that after the `complete` method is called asynchronously, the continuous progress continues.

The fake fetch method basically does this:
```
    this.LoadingBar.continuousStart(0);
    setTimeout(() => this.complete(), 2000);
```

This PR is a quick attempt to fix this (works for me 😄)