### PR TITLE
update onLoaderFinished type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ type IProps = {
   shadow?: boolean
   background?: string
   height?: number
-  onLoaderFinished?: () => {}
+  onLoaderFinished?: () => void
   className?: string
   loaderSpeed?: number
   transitionTime?: number


### PR DESCRIPTION
return type of `onLoaderFinished` should be void, otherwise user has to return `{}` from this callback which not make sense