### PR TITLE
add ref to keep track if component is mounted or not

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   forwardRef,
   useImperativeHandle,
+  useRef,
 } from 'react'
 import { useInterval } from './useInterval'
 import { randomInt } from './utils'
@@ -39,6 +40,7 @@ const LoadingBar = forwardRef(
     }: IProps,
     ref
   ) => {
+    const isMounted = useRef(false);
     const [localProgress, localProgressSet] = useState<number>(0)
     const [pressedContinuous, setPressedContinuous] = useState<{
       active: boolean
@@ -86,6 +88,13 @@ const LoadingBar = forwardRef(
     const [shadowStyle, shadowStyleSet] = useState<CSSProperties>(
       initialShadowStyles
     )
+
+    useEffect(() => {
+      isMounted.current = true;
+      return () => {
+        isMounted.current = false;
+      }
+    }, []);
 
     useImperativeHandle(ref, () => ({
       continuousStart(startingValue: number, refreshRate: number = 1000) {
@@ -179,6 +188,9 @@ const LoadingBar = forwardRef(
         }
 
         setTimeout(() => {
+          if (!isMounted.current) {
+            return;
+          }
           // now it can fade out
           loaderStyleSet({
             ...loaderStyle,
@@ -189,6 +201,9 @@ const LoadingBar = forwardRef(
           })
 
           setTimeout(() => {
+            if (!isMounted.current) {
+              return;
+            }
             // here we wait for it to fade
             if (pressedContinuous.active) {
               // if we have continous loader just ending, we kill it and reset it


### PR DESCRIPTION
Because of the timeouts used in the checkIfFull method it can happen, that the component is unmounted, when the state should be updated. the proposed ref isMounted is a simple solution for that.