### PR TITLE
Export `ref` type for TS

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,13 @@ type IProps = {
   waitingTime?: number
 }
 
-const LoadingBar = forwardRef(
+export type LoadingBarRef = {
+  continuousStart: (startingValue: number, refreshRate: number) => void
+  staticStart: (startingValue: number) => void
+  complete: () => void;
+}
+
+const LoadingBar = forwardRef<LoadingBarRef, IProps>(
   (
     {
       progress,
@@ -36,7 +42,7 @@ const LoadingBar = forwardRef(
       loaderSpeed = 500,
       waitingTime = 1000,
       shadow = true,
-    }: IProps,
+    },
     ref
   ) => {
     const [localProgress, localProgressSet] = useState<number>(0)


### PR DESCRIPTION
We couldn't know the type of the ref in the former code.

```tsx
// Before
cosnt App = () => {
  // What type does this ref have!?
  const ref = useRef(null)

  return (
    <>
      <LoadingBar ref={ref} />
      <button onClock={() => ref.current.continuousStart()}>
        Start
      </button>
    </>
  )
}

// After
import { LoadingBarRef } from 'react-top-loading-bar'

cosnt App = () => {
  // yay! we know the type of the ref!
  const ref = useRef<LoadingBarRef>(null)

  return (
    <>
      <LoadingBar ref={ref} />
      <button onClock={() => ref.current.continuousStart()}>
        Start
      </button>
    </>
  )
}
```
