### PR TITLE
Broaden peer dependency to include react ^17

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16 || ^17"
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",


### PR DESCRIPTION
We and others are using this with react 17.* without problems, so probably best to quiet down the peer dependency warnings.

Fixes #49