### PR TITLE
Use synchronous useRef to prevent race condition problem

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,7 +55,7 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
   ) => {
     const isMounted = useRef(false);
     const [localProgress, localProgressSet] = useState<number>(0)
-    const [pressedContinuous, setPressedContinuous] = useState<{
+    const pressedContinuous = useRef<{
       active: boolean
       startingValue: number
       refreshRate: number
@@ -120,16 +120,16 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
         }
 
         const val = startingValue || randomInt(10, 20)
-        setPressedContinuous({
+        pressedContinuous.current = {
           active: true,
           refreshRate,
           startingValue,
-        })
+        }
         localProgressSet(val)
         checkIfFull(val)
       },
       staticStart(startingValue: number) {
-        if (pressedContinuous.active) return
+        if (pressedContinuous.current.active) return
         if (usingProps) {
           console.warn(
             "react-top-loading-bar: You can't use both controlling by props and ref methods to control the bar!"
@@ -218,12 +218,12 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
               return;
             }
             // here we wait for it to fade
-            if (pressedContinuous.active) {
+            if (pressedContinuous.current.active) {
               // if we have continous loader just ending, we kill it and reset it
-              setPressedContinuous({
-                ...pressedContinuous,
+              pressedContinuous.current = {
+                ...pressedContinuous.current,
                 active: false,
-              })
+              }
               localProgressSet(0)
               checkIfFull(0)
             }
@@ -271,7 +271,7 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
           checkIfFull(localProgress + random)
         }
       },
-      pressedContinuous.active ? pressedContinuous.refreshRate : null
+      pressedContinuous.current.active ? pressedContinuous.current.refreshRate : null
     )
 
     return (


### PR DESCRIPTION
Fixes klendi/react-top-loading-bar#52