### PR TITLE
Bump to React 18

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -16,11 +16,12 @@
       }
     },
     "..": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "integrity": "sha512-wkRlK9Rte4TU817GDcjlsCoDOxrrnvsNvK609FKyio0EIrmmqjQDz5DB8HbN88CHNZBy5Lh/OBALc03ioWFPuQ==",
+      "license": "MIT",
       "devDependencies": {
         "@types/jest": "^25.1.4",
-        "@types/react": "^16.9.27",
+        "@types/react": "^18.0.9",
         "@typescript-eslint/eslint-plugin": "^2.26.0",
         "@typescript-eslint/parser": "^2.26.0",
         "babel-eslint": "^10.0.3",
@@ -47,7 +48,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
+        "react": "^16 || ^17 || ^18"
       }
     },
     "../node_modules/@babel/code-frame": {
@@ -25215,7 +25216,7 @@
       "version": "file:..",
       "requires": {
         "@types/jest": "^25.1.4",
-        "@types/react": "^16.9.27",
+        "@types/react": "^18.0.9",
         "@typescript-eslint/eslint-plugin": "^2.26.0",
         "@typescript-eslint/parser": "^2.26.0",
         "babel-eslint": "^10.0.3",
@@ -27488,8 +27489,7 @@
           "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
         },
         "@types/react": {
-          "version": "16.9.34",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.34.tgz",
+          "version": "https://registry.npmjs.org/@types/react/-/react-16.9.34.tgz",
           "integrity": "sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==",
           "dev": true,
           "requires": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -40,8 +40,8 @@
         "microbundle-crl": "^0.13.8",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.4",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
         "react-scripts": "^3.4.1"
       },
       "engines": {
@@ -25235,8 +25235,8 @@
         "microbundle-crl": "^0.13.8",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.4",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
         "react-scripts": "^3.4.1"
       },
       "dependencies": {
@@ -39970,7 +39970,7 @@
           }
         },
         "react": {
-          "version": "16.13.1",
+          "version": "file:https:/registry.npmjs.org/react/-/react-16.13.1.tgz",
           "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
           "requires": {
             "loose-envify": "^1.1.0",
@@ -40289,7 +40289,7 @@
           }
         },
         "react-dom": {
-          "version": "16.13.1",
+          "version": "file:https:/registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
           "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
           "requires": {
             "loose-envify": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "react-top-loading-bar",
       "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^25.1.4",
-        "@types/react": "^16.9.27",
+        "@types/react": "^18.0.9",
         "@typescript-eslint/eslint-plugin": "^2.26.0",
         "@typescript-eslint/parser": "^2.26.0",
         "babel-eslint": "^10.0.3",
@@ -29,15 +28,15 @@
         "microbundle-crl": "^0.13.8",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.4",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": "^18.1.0",
+        "react-dom": "^18.1.0",
         "react-scripts": "^3.4.1"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
+        "react": "^16 || ^17 || ^18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3151,9 +3150,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.21.tgz",
-      "integrity": "sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
+      "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -17111,14 +17110,12 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
+      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
       "dev": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -17459,18 +17456,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.22.0"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
+        "react": "^18.1.0"
       }
     },
     "node_modules/react-error-overlay": {
@@ -19148,13 +19143,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
       "dev": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -25034,9 +25028,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.21.tgz",
-      "integrity": "sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
+      "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -36357,14 +36351,12 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
+      "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-app-polyfill": {
@@ -36633,15 +36625,13 @@
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.22.0"
       }
     },
     "react-error-overlay": {
@@ -37964,13 +37954,12 @@
       }
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16 || ^17"
+    "react": "^16 || ^17 || ^18"
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",
-    "@types/react": "^16.9.27",
+    "@types/react": "^18.0.9",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "microbundle-crl": "^0.13.8",
@@ -51,8 +51,8 @@
     "gh-pages": "^2.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
     "react-scripts": "^3.4.1"
   },
   "files": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useInterval } from './useInterval'
 import { randomInt } from './utils'
 
-type IProps = {
+export type IProps = {
   progress?: number
   color?: string
   shadow?: boolean
@@ -283,9 +283,5 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
     )
   }
 )
-
-export {
-  IProps,
-}
 
 export default LoadingBar

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "moduleResolution": "node",
     "jsx": "react",
     "sourceMap": true,
@@ -15,8 +18,22 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "target": "es5",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "example"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "example"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "esnext",
-    "lib": [
-      "dom",
-      "esnext"
-    ],
+    "lib": ["dom", "esnext"],
     "moduleResolution": "node",
     "jsx": "react",
     "sourceMap": true,
@@ -18,22 +15,8 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "allowSyntheticDefaultImports": true,
-    "target": "es5",
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "example"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "example"]
 }


### PR DESCRIPTION
It seems only dependency changes are needed here to bump it to React 18. 
<img width="1390" alt="Screenshot 2022-05-21 at 2 23 22 AM" src="https://user-images.githubusercontent.com/947595/169598884-0a694db4-de39-47ef-b2cb-73f4b56e2efe.png">

(on the screenshot, React.version is printed)

Note: I had to change IProps export to `export type` cause some of the build scripts in package.json were complaining about it.

fixes #63