### PR TITLE
Feature/75 halt fading at 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ export default App
 | style       | CSSProperties   |    | The style attribute to loader's div                                                                                             |
 | containerStyle       | CSSProperties   |    | The style attribute to loader's container                                                                                            |
 | shadowStyle       | CSSProperties   |    | The style attribute to loader's shadow                                                                                          |
-| transitionTime   | Number   | `300`   | Fade transition time in miliseconds.                                                                                              |
+| transitionTime   | Number   | `300`   | Fade transition time in miliseconds.
+| fade             | Boolean  | `true`  | Fade status when the progress bar reaches at 100%.                                                                                                |
 | loaderSpeed      | Number   | `500`   | Loader transition speed in miliseconds.                                                                                           |
 | waitingTime      | Number   | `1000`  | The delay we wait when bar reaches 100% before we proceed fading the loader out.                                                  |
 | className        | String   |         | You can provide a class you'd like to add to the loading bar to add some styles to it                                             |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ export type IProps = {
   style?: CSSProperties
   containerStyle?: CSSProperties
   shadowStyle?: CSSProperties
+  fade?: boolean
 }
 
 export type LoadingBarRef = {
@@ -49,7 +50,8 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
       containerStyle = {},
       style = {},
       shadowStyle: shadowStyleProp = {},
-      containerClassName = ''
+      containerClassName = '',
+      fade = true,
     },
     ref
   ) => {
@@ -195,77 +197,84 @@ const LoadingBar = forwardRef<LoadingBarRef, IProps>(
         loaderStyleSet({
           ...loaderStyle,
           width: '100%',
-        })
+        });
         if (shadow) {
           shadowStyleSet({
             ...shadowStyle,
             left: _progress - 10 + '%',
-          })
+          });
         }
 
-        setTimeout(() => {
-          if (!isMounted.current) {
-            return;
-          }
-          // now it can fade out
-          loaderStyleSet({
-            ...loaderStyle,
-            opacity: 0,
-            width: '100%',
-            transition: `all ${transitionTime}ms ease-out`,
-            color: color,
-          })
-
+        // Check if the fade prop is true before initiating fade-out
+        if (fade) {
           setTimeout(() => {
             if (!isMounted.current) {
               return;
             }
-            // here we wait for it to fade
-            if (pressedContinuous.current.active) {
-              // if we have continuous loader just ending, we kill it and reset it
+            // now it can fade out
+            loaderStyleSet({
+              ...loaderStyle,
+              opacity: 0,
+              width: '100%',
+              transition: `all ${transitionTime}ms ease-out`,
+              color: color,
+            });
 
-              pressedContinuous.current = {
-                ...pressedContinuous.current,
-                active: false,
-              };
+            setTimeout(() => {
+              if (!isMounted.current) {
+                return;
+              }
+              // here we wait for it to fade
+              if (pressedContinuous.current.active) {
+                // if we have continuous loader just ending, we kill it and reset it
 
-              localProgressSet(0)
-              checkIfFull(0)
-            }
+                pressedContinuous.current = {
+                  ...pressedContinuous.current,
+                  active: false,
+                };
 
-            if (pressedStaticStart.active) {
-              setStaticStartPressed({
-                ...pressedStaticStart,
-                active: false,
-              })
-              localProgressSet(0)
-              checkIfFull(0)
-            }
+                localProgressSet(0);
+                checkIfFull(0);
+              }
 
-            if (onLoaderFinished) onLoaderFinished()
-            localProgressSet(0)
-            checkIfFull(0)
-          }, transitionTime)
-        }, waitingTime)
+              if (pressedStaticStart.active) {
+                setStaticStartPressed({
+                  ...pressedStaticStart,
+                  active: false,
+                });
+                localProgressSet(0);
+                checkIfFull(0);
+              }
+
+              if (onLoaderFinished) onLoaderFinished();
+              localProgressSet(0);
+              checkIfFull(0);
+            }, transitionTime);
+          }, waitingTime);
+        } else {
+          // If fade is false, the loading bar will not fade out
+          if (onLoaderFinished) onLoaderFinished();
+        }
       } else {
+        // existing code for loading progress less than 100%
         loaderStyleSet((_loaderStyle) => {
           return {
             ..._loaderStyle,
             width: _progress + '%',
             opacity: 1,
             transition: _progress > 0 ? `all ${loaderSpeed}ms ease` : '',
-          }
-        })
+          };
+        });
 
         if (shadow) {
           shadowStyleSet({
             ...shadowStyle,
             left: _progress - 5.5 + '%',
             transition: _progress > 0 ? `all ${loaderSpeed}ms ease` : '',
-          })
+          });
         }
       }
-    }
+    };
 
     useInterval(
       () => {


### PR DESCRIPTION
### Implemented Feature Request from Issue #75

- Added fading status functionality to the loading bar component.
- If `fade={true}`, the bar will fade out at 100% as it currently does.
- if `fade={false}`, the progress bar will stop at 100% without fading.
- I also modified the README file and included details about the `fade` prop in the Prop section.
- Usage example:
```
<LoadingBar
    color='#f11946'
    progress={progress}
    fade={false}  // true: Default
/>
```
> This implementation addresses the requested feature and provides a clear usage example for the new fade prop.