### PR TITLE
Fix: broken example urls

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -146,9 +146,9 @@ const App: React.FC = () => {
           href={
             usingRef
               ? usingHooks
-                ? "https://github.com/klendi/react-top-loading-bar/blob/master/example/examples/ExampleWithContainer.tsx"
-                : "https://github.com/klendi/react-top-loading-bar/blob/master/example/examples/ExampleWithRef.tsx"
-              : "https://github.com/klendi/react-top-loading-bar/blob/master/example/examples/ExampleWithState.tsx"
+                ? "https://github.com/klendi/react-top-loading-bar/blob/master/example/src/examples/ExampleWithContainer.tsx"
+                : "https://github.com/klendi/react-top-loading-bar/blob/master/example/src/examples/ExampleWithRef.tsx"
+              : "https://github.com/klendi/react-top-loading-bar/blob/master/example/src/examples/ExampleWithState.tsx"
           }
         >
           Example


### PR DESCRIPTION
Fixing the broken example urls from the documentation playground page
![image](https://github.com/user-attachments/assets/b6ec796b-7f80-4bea-8be3-10b38a4cd631)
